### PR TITLE
add: markdown2pdf project

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following list will provide you with detailed insights and resources to enha
 - [matador](https://github.com/Kodylow/matador) - An "API reverse proxy" using L402.
 - [bitcoinsearch Chat](https://chat.bitcoinsearch.xyz) - ChatGPT-like application designed to help you learn about bitcoin technology and its history.
 - L402 Shield - Example of an API to access Bitcoin blockchain data paywalled with the L402 protocol. [Live demo](https://l402.starknetonbitcoin.com/) - [L402 Backend in Rust](https://github.com/AbdelStark/l402-server-example-rs) - [L402 Frontend using Nextjs / React](https://github.com/AbdelStark/l402-shield)
+- [markdown2pdf.ai](https://markdown2pdf.ai) - A simple service designed to enable AI agents to create PDFs from Markdown output, using L402 payments.
 
 <a name="tools" />
 


### PR DESCRIPTION
As discussed with @positiveblue on our call yesterday, we would love to add this simple service we have built to explore the use of the L402 protocol and fewsats.com to your great list of L402 related services. Essentially this is a high0quality PDF renderer for markdown powered by sats payments. You will see on the documentation site we would like to highlight fewsats.com as a simple means of enabling people to equip their agents with payment mechanisms for handling the sats for PDF exchange. Keep up the great work with fewsats.com and excited to follow your progress.