### PR TITLE
Add l402-toolkit, l402.directory, and Hyperdope

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following list will provide you with detailed insights and resources to enha
 | [lsat-js](https://github.com/Tierion/lsat-js)                               | javascript | A javascript library for working with L402                                                   |
 | [l402-ts](https://github.com/sulusolutions/l402-ts)                         | typescript | A client library for working with L402                                                       |
 | [gol402](https://github.com/sulusolutions/gol402)                           | golang     | A client library for working with L402                                                       |
+| [l402-toolkit](https://github.com/EricRHadley/l402-toolkit)                 | javascript | Server-side L402 module and agent discovery patterns for Node.js. Stateless verification, per-resource caveats, one dependency |
 
 
 <a name="projects" />
@@ -74,6 +75,8 @@ The following list will provide you with detailed insights and resources to enha
 - [bitcoinsearch Chat](https://chat.bitcoinsearch.xyz) - ChatGPT-like application designed to help you learn about bitcoin technology and its history.
 - L402 Shield - Example of an API to access Bitcoin blockchain data paywalled with the L402 protocol. [Live demo](https://l402.starknetonbitcoin.com/) - [L402 Backend in Rust](https://github.com/AbdelStark/l402-server-example-rs) - [L402 Frontend using Nextjs / React](https://github.com/AbdelStark/l402-shield)
 - [Maximum Sats](https://maximumsats.com) - L402-paywalled AI API (text and image generation) built on Cloudflare Workers with LNbits. Includes developer tutorials for building L402 services.
+- [l402.directory](https://l402.directory) - Service registry for L402 APIs. Health-checked, payment-verified listings (listing requires paying an L402 invoice). Machine-readable discovery at GET /api.
+- [Hyperdope](https://hyperdope.com) - L402-gated video streaming. 10 sats per video, HLS with token-authenticated segments, no user accounts. Mainnet.
 
 <a name="tools" />
 


### PR DESCRIPTION
Adds three mainnet L402 projects:

**Libraries:**
- [l402-toolkit](https://github.com/EricRHadley/l402-toolkit) — Server-side L402 module for Node.js with documented agent discovery patterns. Stateless macaroon verification, per-resource caveats, single dependency (macaroons.js).

**Projects:**
- [l402.directory](https://l402.directory) — Service registry for L402 APIs. Listings are health-checked and payment-verified (submitting a listing requires paying an L402 invoice). Machine-readable discovery endpoint at `GET /api`.
- [Hyperdope](https://hyperdope.com) — L402-gated video streaming. 10 sats per video via Lightning, HLS playback with token-authenticated segments, no user accounts. Running on mainnet.

All three are live and accepting real Lightning payments.