### PR TITLE
Add gateless - TypeScript L402 client with Fewsats v0.2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following list will provide you with detailed insights and resources to enha
 | [l402-ts](https://github.com/sulusolutions/l402-ts)                         | typescript | A client library for working with L402                                                       |
 | [gol402](https://github.com/sulusolutions/gol402)                           | golang     | A client library for working with L402                                                       |
 | [l402-toolkit](https://github.com/EricRHadley/l402-toolkit)                 | javascript | Server-side L402 module and agent discovery patterns for Node.js. Stateless verification, per-resource caveats, one dependency |
+| [satpathdev/gateless](https://github.com/satpathdev/gateless)               | typescript | Sovereign L402 client for AI agents. Supports classic L402 and Fewsats v0.2. Connects to your own LND node. |
 
 
 <a name="projects" />


### PR DESCRIPTION
Gateless is a TypeScript library that lets AI agents autonomously pay for L402-protected resources over Lightning. It supports both classic L402 (macaroon + invoice) and Fewsats L402 v0.2 (offers + payment requests).

- npm: https://www.npmjs.com/package/@satpath/gateless
- GitHub: https://github.com/satpathdev/gateless
- Tested against stock.l402.org with real Lightning payments
- Self-sovereign: connects to your own LND node