### PR TITLE
Add Satoshi BTC API — L402 Bitcoin intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following list will provide you with detailed insights and resources to enha
 - [Lightning Memory](https://github.com/singularityjason/lightning-memory) - Decentralized agent memory for the Lightning economy. Vendor reputation, spending anomaly detection, Nostr identity (BIP-340), L402 payment gateway for agent-to-agent knowledge markets. MCP native.
 - [Satring](https://satring.com) - L402 service directory. Browse, search, and rate Lightning-paywalled APIs. Free JSON API for agent discovery, L402-gated submissions. [Source](https://github.com/toadlyBroodle/satring).
 - [Hyperdope](https://hyperdope.com) - L402-gated video streaming. 10 sats per video, HLS with token-authenticated segments, no user accounts. Mainnet.
-- [Satoshi BTC Intelligence API](https://api.satoshiapi.io/health) - Pay-per-request Bitcoin data API (price, mempool fees, block height, sentiment, DCA signals). 10-50 sats/call via native L402 macaroons. Python + LND, no Aperture. Mainnet.
+- [Satoshi BTC Intelligence API](https://github.com/SatoshiAPI/satoshi-btc-api) - Pay-per-request Bitcoin data API (price, mempool fees, block height, sentiment, DCA signals). 10-50 sats/call via native L402 macaroons. Python + LND, no Aperture. Mainnet. [Live](https://api.satoshiapi.io/health).
 
 <a name="tools" />
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The following list will provide you with detailed insights and resources to enha
 - [Lightning Memory](https://github.com/singularityjason/lightning-memory) - Decentralized agent memory for the Lightning economy. Vendor reputation, spending anomaly detection, Nostr identity (BIP-340), L402 payment gateway for agent-to-agent knowledge markets. MCP native.
 - [Satring](https://satring.com) - L402 service directory. Browse, search, and rate Lightning-paywalled APIs. Free JSON API for agent discovery, L402-gated submissions. [Source](https://github.com/toadlyBroodle/satring).
 - [Hyperdope](https://hyperdope.com) - L402-gated video streaming. 10 sats per video, HLS with token-authenticated segments, no user accounts. Mainnet.
+- [Satoshi BTC Intelligence API](https://api.satoshiapi.io/health) - Pay-per-request Bitcoin data API (price, mempool fees, block height, sentiment, DCA signals). 10-50 sats/call via native L402 macaroons. Python + LND, no Aperture. Mainnet.
 
 <a name="tools" />
 


### PR DESCRIPTION
## New L402 Service: Satoshi BTC API

**URL:** https://satoshiapi.io  
**API:** https://api.satoshiapi.io  
**Source:** https://github.com/BodyOdor/satoshi-btc-api

### What it does
Real-time Bitcoin intelligence API gated behind L402 Lightning payments. Pay 10-25 sats per request — no accounts, no subscriptions, no API keys.

### Endpoints
| Endpoint | Price | Data |
|---|---|---|
| /price | 10 sats | BTC/USD + 24h change |
| /mempool | 10 sats | Fee estimates (sat/vB) |
| /blockheight | 10 sats | Block height + hashrate |
| /sentiment | 25 sats | Fear & Greed index |
| /health | Free | Service status |

### Technical
- Native Python L402 middleware (no Aperture dependency)
- LND node running over Tor v3
- Cloudflare Tunnel for public HTTPS
- Open source