### PR TITLE
Add PowForge L402 services and libraries (DoI Oracle, CAPTCHA, gate, paste)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ The following list will provide you with detailed insights and resources to enha
 | [l402-ts](https://github.com/sulusolutions/l402-ts)                         | typescript | A client library for working with L402                                                       |
 | [gol402](https://github.com/sulusolutions/gol402)                           | golang     | A client library for working with L402                                                       |
 | [l402-toolkit](https://github.com/EricRHadley/l402-toolkit)                 | javascript | Server-side L402 module and agent discovery patterns for Node.js. Stateless verification, per-resource caveats, one dependency |
+| [@powforge/identity](https://www.npmjs.com/package/@powforge/identity) | JavaScript | Depth-of-Identity SDK, computes 5-dimension Schnorr-signed identity weight from Nostr events |
+| [@powforge/captcha](https://www.npmjs.com/package/@powforge/captcha) | JavaScript | Drop-in L402-compatible PoW CAPTCHA client and verifier |
 
 
 <a name="projects" />
@@ -82,6 +84,10 @@ The following list will provide you with detailed insights and resources to enha
 
 <a name="tools" />
 
+- [PowForge DoI Oracle](https://identity.powforge.dev/oracle/info) - Schnorr-signed Depth-of-Identity score for any Nostr pubkey, L402-paywalled. The signature is the product. [Whitepaper](https://powforge.dev/whitepaper/) - [Source](https://gitlab.com/powforge/sats-challenge)
+- [PowForge pow-gate](https://gate.powforge.dev) - PoW + L402 gated HTTP reverse proxy. Pay sats or compute sats.
+- [PowForge pow-captcha](https://captcha.powforge.dev) - PoW CAPTCHA with L402 skip tier. [npm](https://www.npmjs.com/package/@powforge/captcha)
+- [PowForge pow-paste](https://paste.powforge.dev) - L402-gated pastebin. Pay a sat, paste stays pinned.
 ## Tools
 
 - [Aperture](https://github.com/lightninglabs/aperture) - HTTP 402 reverse proxy that supports proxying requests for gRPC (HTTP/2) and REST (HTTP/1 and HTTP/2) backends using the L402 


### PR DESCRIPTION
Adds PowForge's L402-shipped services and libraries.

**DoI Oracle** at `identity.powforge.dev/oracle/doi-score` is one category up from the services currently on the list — it prices *identity*, not content or compute. An agent calling an L402 endpoint can call this Oracle for a Schnorr-signed depth score on the caller's key across five dimensions of irreversible work (access via PoW solves, economic via Lightning receipts, temporal via OTS anchors, social via vouch-cycle-discounted follows, spatial via kind:3333 hops), then adjust invoice amounts by depth. Full thesis at https://powforge.dev/whitepaper/.

**pow-gate**, **pow-captcha**, **pow-paste** are direct L402-gated services shipped under the PowForge label.

**@powforge/identity** (v0.5.2) is the client-side SDK that implements the score computation against Nostr events; **@powforge/captcha** is the drop-in PoW CAPTCHA client.

All services run behind Caddy with wildcard TLS on a DO droplet. Source at https://gitlab.com/powforge/sats-challenge.

Try the Oracle:

```bash
curl -s https://identity.powforge.dev/oracle/info
curl -s -X POST https://identity.powforge.dev/oracle/doi-score \
  -H 'Content-Type: application/json' \
  -d '{"npub":"npub1..."}'
```

The signature is the product — the signed JSON envelope verifies offline against the oracle npub.