### PR TITLE
Add SaturnZap to Libraries and Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following list will provide you with detailed insights and resources to enha
 | [l402-ts](https://github.com/sulusolutions/l402-ts)                         | typescript | A client library for working with L402                                                       |
 | [gol402](https://github.com/sulusolutions/gol402)                           | golang     | A client library for working with L402                                                       |
 | [l402-toolkit](https://github.com/EricRHadley/l402-toolkit)                 | javascript | Server-side L402 module and agent discovery patterns for Node.js. Stateless verification, per-resource caveats, one dependency |
+| [SaturnZap](https://github.com/lqwdtech/SaturnZap)                          | python     | Non-custodial Lightning wallet for autonomous AI agents. Runs its own LDK node, pays L402-gated APIs from the CLI or via a built-in MCP server |
 
 
 <a name="projects" />
@@ -79,6 +80,7 @@ The following list will provide you with detailed insights and resources to enha
 - [Lightning Memory](https://github.com/singularityjason/lightning-memory) - Decentralized agent memory for the Lightning economy. Vendor reputation, spending anomaly detection, Nostr identity (BIP-340), L402 payment gateway for agent-to-agent knowledge markets. MCP native.
 - [Satring](https://satring.com) - L402 service directory. Browse, search, and rate Lightning-paywalled APIs. Free JSON API for agent discovery, L402-gated submissions. [Source](https://github.com/toadlyBroodle/satring).
 - [Hyperdope](https://hyperdope.com) - L402-gated video streaming. 10 sats per video, HLS with token-authenticated segments, no user accounts. Mainnet.
+- [SaturnZap](https://github.com/lqwdtech/SaturnZap) - Non-custodial Lightning wallet built for autonomous AI agents. The agent runs its own LDK node, opens channels, and pays L402-gated APIs from the CLI or via a built-in MCP server. PyPI: `saturnzap`.
 
 <a name="tools" />
 


### PR DESCRIPTION
## Summary

Adds [SaturnZap](https://github.com/lqwdtech/SaturnZap) to the **Libraries** table and the **Projects** list.

SaturnZap is a non-custodial, CLI-first Lightning Network wallet built specifically for autonomous AI agents. Each agent runs its own LDK node, opens channels, and pays L402-gated APIs either from the CLI or via a built-in MCP (Model Context Protocol) server.

## Why it fits

- **Libraries (python)** — installable Python package (`uv tool install saturnzap`) that gives any agent the ability to traverse L402-paywalled endpoints. Conceptually a sibling to LangChainBitcoin / l402-python on the *client* side.
- **Projects** — a real-world application of the L402 client surface, in production use by the LQWD AI Launchpad.

## Project info

- Repo: https://github.com/lqwdtech/SaturnZap
- PyPI: `saturnzap` (latest: v1.3.1)
- License: MIT
- Topics: `l402`, `ldk`, `lightning`, `mcp`, `ai-agents`, `bitcoin`, `non-custodial-wallet`, `python`

## Test plan

- [x] Diff is two additions, no whitespace churn
- [x] Library-table column count and pipe alignment preserved
- [x] Project bullet matches existing entry style (name link, hyphen, description)